### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://testforazuredevops.visualstudio.com/ea336358-316a-4353-8ad1-148f910d30cf/402dc694-27db-4a89-a138-553362629bdc/_apis/work/boardbadge/e8b94f26-0573-47cf-a0b9-dd743fee1324)](https://testforazuredevops.visualstudio.com/ea336358-316a-4353-8ad1-148f910d30cf/_boards/board/t/402dc694-27db-4a89-a138-553362629bdc/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://testforazuredevops.visualstudio.com/ea336358-316a-4353-8ad1-148f910d30cf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.